### PR TITLE
Fix `do.hover` altering grouping in `yPlot` resulting in weird ranked jitter points

### DIFF
--- a/R/yPlot.R
+++ b/R/yPlot.R
@@ -486,9 +486,11 @@ yPlot <- function(
             }
 
             jitter.aes.args <- list()
-            # if (do.hover) {
-            #     jitter.aes.args$text <-  "hover.string"
-            # }
+            jitter.aes.args$group <- group.by
+
+            if (do.hover) {
+                jitter.aes.args$text <-  "hover.string"
+            }
 
             # If shape.by given, use it. Else, shapes[1] which = dots (16) by default
             if (!is.null(shape.by)) {


### PR DESCRIPTION
This adds a `group` aesthetic to the `aes_string` call prevent grouping change in `yPlot` with `do.hover = TRUE`. This behavior is noted here: https://github.com/tidyverse/ggplot2/issues/3749

And a few other issues. I can't find any examples where this change breaks things, but your eye may be able to spot them more easily.

```r
yPlot(data_frame = example_df, group.by = "timepoint", 
  var = c("gene1", "gene2"), plots = "jitter", do.hover = TRUE, 
  hover.data = c("gene1"), jitter.size = 2)
```

![image](https://github.com/dtm2451/dittoViz/assets/10225716/eaecc4ab-373f-4be2-bbe3-5bc72ff2f8ae)
