### PR TITLE
Add three-color color scale functionality to `scatterPlot` & `scatterHex` a la `dittoDotPlot`

### DIFF
--- a/R/scatterPlot.R
+++ b/R/scatterPlot.R
@@ -82,8 +82,25 @@
 #' @param legend.color.size,legend.shape.size Numbers representing the size of shapes in the color and shape legends (for discrete variable plotting).
 #' Default = 5. *Enlarging the icons in the colors legend is incredibly helpful for making colors more distinguishable by color blind individuals.
 #' @param min.color color for \code{min} value of numeric \code{color.by}-data. Default = yellow
+#' @param mid.color NULL (default), "ryb", "rwb", "rgb", or a color to use for the midpoint of a three-color color scale.
+#' \emph{This parameter acts a switch between using a 2-color scale or a 3-color scale}:\itemize{
+#' \item When left NULL, the 2-color scale runs from \code{min.color} to \code{max.color}, using \code{\link[ggplot2]{scale_fill_gradient}}.
+#' \item When given a color, the 3-color scale runs from \code{min.color} to \code{mid.color} to \code{max.color}, using \code{\link[ggplot2]{scale_fill_gradient2}}.
+#' \item{
+#' When given \emph{\code{"ryb"}, \code{"rwb"}, or \code{"rgb"} serves as a \strong{single-point, quick switch to a "standard" 3-color scale}} by also updating the \code{min.color} and \code{max.color}.
+#' Doing so sets:\itemize{
+#'     \item \code{max.color} to a red,
+#'     \item \code{min.color} to a blue,
+#'     \item and \code{mid.color} to either a yellow ("r\emph{y}b"), "white" ("r\emph{w}b"), or "gray97" ("r\emph{g}b", gray not green).
+#'     \item Actual colors used are inspired by \href{http://www.colorbrewer.org}{ColorBrewer} "RdYlBu" and "RdBu" palettes.
+#' }
+#' Thus, the 3-color scale runs from a blue to one of a yellow, "white", or "gray97" to a red, using \code{\link[ggplot2]{scale_fill_gradient2}}.
+#' }
+#' }
 #' @param max.color color for \code{max} value of numeric \code{color.by}-data. Default = blue
 #' @param min.value,max.value Number which sets the \code{color.by}-data value associated with the minimum or maximum colors.
+#' @param mid.value Number or "make" (default) which sets the value associated with the \code{mid.color} of the three-color scale.
+#'   Ignored when \code{mid.color} is left as NULL.
 #' @param legend.color.breaks Numeric vector which sets the discrete values to label in the color-scale legend for \code{color.by}-data.
 #' @param legend.color.breaks.labels String vector, with same length as \code{legend.color.breaks}, which sets the labels for the tick marks of the color-scale.
 #' @param main String, sets the plot title.
@@ -159,7 +176,7 @@
 #' @seealso
 #' \code{\link{scatterHex}} for a hex-binned version that can be useful when points are very dense.
 #'
-#' @author Daniel Bunis
+#' @author Daniel Bunis, Jared Andrews
 #' @export
 #' @examples
 #' example("dittoExampleData", echo = FALSE)
@@ -286,8 +303,10 @@ scatterPlot <- function(
     rename.color.groups = NULL,
     rename.shape.groups = NULL,
     min.color = "#F0E442",
+    mid.color = NULL,
     max.color = "#0072B2",
     min.value = NA,
+    mid.value = "make",
     max.value = NA,
     plot.order = c("unordered", "increasing", "decreasing", "randomize"),
     xlab = x.by,
@@ -372,7 +391,7 @@ scatterPlot <- function(
         Target_data, Others_data, cols_use$x.by, cols_use$y.by,
         cols_use$color.by, cols_use$shape.by, show.others, size, opacity,
         color.panel, colors, do.hover, shape.panel,
-        min.color, max.color, min.value, max.value,
+        min.color, mid.color, max.color, min.value, mid.value, max.value,
         xlab, ylab, main, sub, theme,
         legend.show, legend.color.title, legend.color.size,
         legend.color.breaks, legend.color.breaks.labels, legend.shape.title,
@@ -441,8 +460,10 @@ scatterPlot <- function(
     do.hover,
     shape.panel,
     min.color,
+    mid.color,
     max.color,
     min.value,
+    mid.value,
     max.value,
     xlab,
     ylab,
@@ -491,13 +512,48 @@ scatterPlot <- function(
 
         aes.use <- modifyList(aes.use, aes(color = .data[[color.by]]))
 
+        if (!identical(mid.color, NULL)) {
+            if (mid.color == "ryb") {
+                min.color <- "#4575B4"
+                mid.color <- "#FFFFBF"
+                max.color <- "#D73027"
+            }
+            if (mid.color == "rgb") {
+                min.color <- "#2166AC"
+                mid.color <- "gray97"
+                max.color <- "#B2182B"
+            }
+            if (mid.color == "rwb") {
+                min.color <- "#2166AC"
+                mid.color <- "white"
+                max.color <- "#B2182B"
+            }
+
+            if (identical(mid.value, "make") & is.numeric(Target_data[,color.by])) {
+                max_calc <- ifelse(identical(max.value, NA), max(Target_data[,color.by]), max.value)
+                min_calc <- ifelse(identical(min.value, NA), min(Target_data[,color.by]), min.value)
+                mid.value <- (min_calc + max_calc)/2
+            }
+        }
+
         if (is.numeric(Target_data[,color.by])) {
-            p <- p +
-                scale_colour_gradient(
-                    name = legend.color.title, low= min.color, high = max.color,
-                    limits = c(min.value, max.value),
-                    breaks = legend.color.breaks,
-                    labels = legend.color.breaks.labels)
+
+            color.args <- list(
+                name = legend.color.title,
+                low = min.color, high = max.color,
+                limits = c(min.value,max.value),
+                breaks = legend.color.breaks,
+                labels = legend.color.breaks.labels
+            )
+
+            if (identical(mid.color, NULL)) {
+                p <- p + do.call(scale_color_gradient, color.args)
+            } else {
+                color.args$mid <- mid.color
+                color.args$midpoint <- mid.value
+                p <- p + do.call(scale_color_gradient2, color.args)
+            }
+
         } else {
             p <- p +
                 scale_colour_manual(

--- a/man/scatterHex.Rd
+++ b/man/scatterHex.Rd
@@ -28,10 +28,12 @@ scatterHex(
   min.density = NA,
   max.density = NA,
   min.color = "#F0E442",
+  mid.color = NULL,
   max.color = "#0072B2",
   min.opacity = 0.2,
   max.opacity = 1,
   min = NA,
+  mid = "make",
   max = NA,
   rename.color.groups = NULL,
   xlab = x.by,
@@ -147,9 +149,28 @@ Used no matter whether density is represented through opacity or color.}
 
 \item{min.color, max.color}{color for the min/max values of the color scale.}
 
+\item{mid.color}{NULL (default), "ryb", "rwb", "rgb", or a color to use for the midpoint of a three-color color scale.
+\emph{This parameter acts a switch between using a 2-color scale or a 3-color scale}:\itemize{
+\item When left NULL, the 2-color scale runs from \code{min.color} to \code{max.color}, using \code{\link[ggplot2]{scale_fill_gradient}}.
+\item When given a color, the 3-color scale runs from \code{min.color} to \code{mid.color} to \code{max.color}, using \code{\link[ggplot2]{scale_fill_gradient2}}.
+\item{
+When given \emph{\code{"ryb"}, \code{"rwb"}, or \code{"rgb"} serves as a \strong{single-point, quick switch to a "standard" 3-color scale}} by also updating the \code{min.color} and \code{max.color}.
+Doing so sets:\itemize{
+    \item \code{max.color} to a red,
+    \item \code{min.color} to a blue,
+    \item and \code{mid.color} to either a yellow ("r\emph{y}b"), "white" ("r\emph{w}b"), or "gray97" ("r\emph{g}b", gray not green).
+    \item Actual colors used are inspired by \href{http://www.colorbrewer.org}{ColorBrewer} "RdYlBu" and "RdBu" palettes.
+}
+Thus, the 3-color scale runs from a blue to one of a yellow, "white", or "gray97" to a red, using \code{\link[ggplot2]{scale_fill_gradient2}}.
+}
+}}
+
 \item{min.opacity, max.opacity}{Scalar between [0,1] which sets the minimum or maximum opacity used for the density legend (when color is used for \code{color.by} data and density is shown via opacity).}
 
 \item{min, max}{Number which sets the values associated with the minimum or maximum color for \code{color.by} data.}
+
+\item{mid}{Number or "make" (default) which sets the value associated with the \code{mid.color} of the three-color scale.
+Ignored when \code{mid.color} is left as NULL.}
 
 \item{rename.color.groups}{String vector which sets new names for the identities of \code{color.by} groups.}
 

--- a/man/scatterPlot.Rd
+++ b/man/scatterPlot.Rd
@@ -32,8 +32,10 @@ scatterPlot(
   rename.color.groups = NULL,
   rename.shape.groups = NULL,
   min.color = "#F0E442",
+  mid.color = NULL,
   max.color = "#0072B2",
   min.value = NA,
+  mid.value = "make",
   max.value = NA,
   plot.order = c("unordered", "increasing", "decreasing", "randomize"),
   xlab = x.by,
@@ -159,9 +161,28 @@ Default is a set of 6, \code{c(16,15,17,23,25,8)}, the first being a simple, sol
 
 \item{min.color}{color for \code{min} value of numeric \code{color.by}-data. Default = yellow}
 
+\item{mid.color}{NULL (default), "ryb", "rwb", "rgb", or a color to use for the midpoint of a three-color color scale.
+\emph{This parameter acts a switch between using a 2-color scale or a 3-color scale}:\itemize{
+\item When left NULL, the 2-color scale runs from \code{min.color} to \code{max.color}, using \code{\link[ggplot2]{scale_fill_gradient}}.
+\item When given a color, the 3-color scale runs from \code{min.color} to \code{mid.color} to \code{max.color}, using \code{\link[ggplot2]{scale_fill_gradient2}}.
+\item{
+When given \emph{\code{"ryb"}, \code{"rwb"}, or \code{"rgb"} serves as a \strong{single-point, quick switch to a "standard" 3-color scale}} by also updating the \code{min.color} and \code{max.color}.
+Doing so sets:\itemize{
+    \item \code{max.color} to a red,
+    \item \code{min.color} to a blue,
+    \item and \code{mid.color} to either a yellow ("r\emph{y}b"), "white" ("r\emph{w}b"), or "gray97" ("r\emph{g}b", gray not green).
+    \item Actual colors used are inspired by \href{http://www.colorbrewer.org}{ColorBrewer} "RdYlBu" and "RdBu" palettes.
+}
+Thus, the 3-color scale runs from a blue to one of a yellow, "white", or "gray97" to a red, using \code{\link[ggplot2]{scale_fill_gradient2}}.
+}
+}}
+
 \item{max.color}{color for \code{max} value of numeric \code{color.by}-data. Default = blue}
 
 \item{min.value, max.value}{Number which sets the \code{color.by}-data value associated with the minimum or maximum colors.}
+
+\item{mid.value}{Number or "make" (default) which sets the value associated with the \code{mid.color} of the three-color scale.
+Ignored when \code{mid.color} is left as NULL.}
 
 \item{plot.order}{String. If the data should be plotted based on the order of the color data, sets whether to plot in "increasing", "decreasing", or "randomize"d order.}
 
@@ -402,5 +423,5 @@ out$cols_used
 \code{\link{scatterHex}} for a hex-binned version that can be useful when points are very dense.
 }
 \author{
-Daniel Bunis
+Daniel Bunis, Jared Andrews
 }

--- a/tests/testthat/test-hex.R
+++ b/tests/testthat/test-hex.R
@@ -112,6 +112,21 @@ test_that("scatterHex color scales can be adjusted for continuous color data", {
                                 min = -5, max = 150, min.color = "black", max.color = "orange"),
                     "ggplot")
 
+    ### Manual check: Legend range adjusted and built-in 3-color scale works
+    expect_s3_class(scatterHex(data_frame=df, x.by=cont1, y.by=cont2, cont2,
+                                min = -5, max = 150, mid.color = "ryb"),
+                    "ggplot")
+
+    ### Manual check: Changing midpoint of 3-color color scale works
+    expect_s3_class(scatterHex(data_frame=df, x.by=cont1, y.by=cont2, cont2,
+                                mid = 40, mid.color = "ryb"),
+                    "ggplot")
+
+    ### Manual check: Arbitrary midpoint color for 3-color color scale works
+    expect_s3_class(scatterHex(data_frame=df, x.by=cont1, y.by=cont2, cont2,
+                                mid.color = "green"),
+                    "ggplot")
+
     ### Manual check: Legend has breaks at all 50s in 50 to 300
     expect_s3_class(scatterHex(data_frame=df, x.by=cont1, y.by=cont2, cont2,
                                 legend.color.breaks = seq(50,300,50)),

--- a/tests/testthat/test-scatter.R
+++ b/tests/testthat/test-scatter.R
@@ -19,19 +19,19 @@ test_that("scatterPlot can plot continuous or discrete data", {
 })
 
 test_that("scatterPlot basic tweaks work", {
-    # Manuel Check: big dots
+    # Manual Check: big dots
     expect_s3_class(
         scatterPlot(
             df, "PC1", "PC2", cont,
             size = 10),
         "ggplot")
-    # Manuel Check: triangles
+    # Manual Check: triangles
     expect_s3_class(
         scatterPlot(
             df, "PC1", "PC2", cont,
             shape.panel = 17),
         "ggplot")
-    # Manuel Check: see through large dots
+    # Manual Check: see through large dots
     expect_s3_class(
         scatterPlot(
             df, "PC1", "PC2", cont,
@@ -99,6 +99,27 @@ test_that("scatterPlot color scale can be adjusted", {
             df, "PC1", "PC2", "number",
             min.color = "black",
             max.color = "grey70"),
+        "ggplot")
+
+    ### Manual Check:
+    # 3-color scale
+    expect_s3_class(
+        scatterPlot(
+            df, "PC1", "PC2", "number",
+            min.color = "black",
+            mid.color = "red",
+            max.color = "grey70"),
+        "ggplot")
+
+    ### Manual Check:
+    # 3-color scale with midpoint adjusted
+    expect_s3_class(
+        scatterPlot(
+            df, "PC1", "PC2", "number",
+            min.color = "black",
+            mid.color = "red",
+            max.color = "grey70",
+            mid.value = 100),
         "ggplot")
 })
 
@@ -261,7 +282,7 @@ test_that("scatterPlot can be labeled or circled", {
         "ggplot")
 
     ### Manual Check (next 2)
-    # No movement of lebels, only boxed in 1st
+    # No movement of labels, only boxed in 1st
     expect_s3_class(
         scatterPlot(
             df, "PC1", "PC2", disc,


### PR DESCRIPTION
Pretty much what it says on the tin. Very similar to how you did it in `dittoDotPlot`.

Tests pass, though a bunch of the `scatterHex` ones throw warnings. They already existed and aren't related to this though, I believe.

The `min` and `min.value`, etc, discrepancies between `scatterHex` and `scatterPlot` - are those intentional? May be worth harmonizing them if not.