### PR TITLE
More flexible tooling for arbitrary line additions

### DIFF
--- a/R/barPlot.R
+++ b/R/barPlot.R
@@ -141,7 +141,12 @@ barPlot <- function(
     main = "make",
     sub = NULL,
     legend.show = TRUE,
-    legend.title = NULL) {
+    legend.title = NULL,
+    add.line = NULL,
+    line.linetype = "dashed",
+    line.color = "black",
+    line.linewidth = 0.5,
+    line.opacity = 1) {
 
     scale <- match.arg(scale)
 
@@ -191,6 +196,14 @@ barPlot <- function(
     if (!is.null(split.by)) {
         p <- .add_splitting(
             p, split.by, split.nrow, split.ncol, split.adjust)
+    }
+
+    # Get number of panels so that replicates of aesthetics can be generated if supplied for each line.
+    pp <- ggplot_build(p)
+    num.panels <- length(levels(pp$data[[1]]$PANEL))
+
+    if (!is.null(add.line)) {
+        p <- .add_yline(p, add.line, line.linetype, line.color, line.linewidth, line.opacity, num.panels)
     }
 
     if (!legend.show) {

--- a/R/freqPlot.R
+++ b/R/freqPlot.R
@@ -227,6 +227,8 @@ freqPlot <- function(
     add.line = NULL,
     line.linetype = "dashed",
     line.color = "black",
+    line.linewidth = 0.5,
+    line.opacity = 1,
     legend.show = TRUE,
     legend.title = color.by) {
 
@@ -304,6 +306,8 @@ freqPlot <- function(
         add.line = add.line,
         line.linetype = line.linetype,
         line.color = line.color,
+        line.linewidth = line.linewidth,
+        line.opacity = line.opacity,
         legend.show = legend.show,
         legend.title = legend.title,
         data.out = data.out)

--- a/R/scatterHex.R
+++ b/R/scatterHex.R
@@ -73,7 +73,7 @@
 #' \code{\link{scatterPlot}} for making non-hex-binned scatter plots showing each individual data point.
 #' It is often best to investigate your data with both the individual and hex-bin methods, then pick whichever is the best representation for your particular goal.
 #'
-#' @author Daniel Bunis with some code adapted from Giuseppe D'Agostino
+#' @author Daniel Bunis, Jared Andrews with some code adapted from Giuseppe D'Agostino
 #' @examples
 #' example("dittoExampleData", echo = FALSE)
 #'
@@ -268,9 +268,19 @@ scatterHex <- function(
         add.xline = NULL,
         xline.linetype = "dashed",
         xline.color = "black",
+        xline.linewidth = 0.5,
+        xline.opacity = 1,
         add.yline = NULL,
         yline.linetype = "dashed",
         yline.color = "black",
+        yline.linewidth = 0.5,
+        yline.opacity = 1,
+        add.abline = NULL,
+        abline.slope = 1,
+        abline.linetype = "solid",
+        abline.color = "black",
+        abline.linewidth = 0.5,
+        abline.opacity = 1,
         legend.show = TRUE,
         legend.color.title = "make",
         legend.color.breaks = waiver(),
@@ -349,14 +359,28 @@ scatterHex <- function(
         xlab, ylab, main, sub, theme, legend.show,
         legend.color.title, legend.color.breaks, legend.color.breaks.labels,
         legend.density.title, legend.density.breaks, legend.density.breaks.labels,
-        show.grid.lines,
-        add.xline, xline.linetype, xline.color,
-        add.yline, yline.linetype, yline.color)
+        show.grid.lines)
 
     ### Add extra features
     if (!is.null(cols_use$split.by)) {
         p <- .add_splitting(
             p, cols_use$split.by, split.nrow, split.ncol, split.adjust)
+    }
+
+    # Get number of panels so that replicates of aesthetics can be generated if supplied for each line.
+    pp <- ggplot_build(p)
+    num.panels <- length(levels(pp$data[[1]]$PANEL))
+
+    if (!is.null(add.xline)) {
+        p <- .add_xline(p, add.xline, xline.linetype, xline.color, xline.linewidth, xline.opacity, num.panels)
+    }
+
+    if (!is.null(add.yline)) {
+        p <- .add_yline(p, add.yline, yline.linetype, yline.color, yline.linewidth, yline.opacity, num.panels)
+    }
+
+    if (!is.null(add.abline)) {
+        p <- .add_abline(p, add.abline, abline.slope, abline.linetype, abline.color, abline.linewidth, abline.opacity, num.panels)
     }
 
     if (do.contour) {
@@ -420,13 +444,7 @@ scatterHex <- function(
         legend.density.title,
         legend.density.breaks,
         legend.density.breaks.labels,
-        show.grid.lines,
-        add.xline,
-        xline.linetype,
-        xline.color,
-        add.yline,
-        yline.linetype,
-        yline.color
+        show.grid.lines
 ) {
 
     if (!show.grid.lines) {
@@ -517,14 +535,6 @@ scatterHex <- function(
         p <- p + do.call(ggplot.multistats::stat_summaries_hex, geom.args)
     } else {
         p <- p + do.call(stat_bin_hex, geom.args)
-    }
-
-    if (!is.null(add.xline)) {
-        p <- p + geom_vline(xintercept = add.xline, linetype = xline.linetype, color = xline.color)
-    }
-
-    if (!is.null(add.yline)) {
-        p <- p + geom_hline(yintercept = add.yline, linetype = yline.linetype, color = yline.color)
     }
 
     if (!legend.show) {

--- a/R/scatterPlot.R
+++ b/R/scatterPlot.R
@@ -105,14 +105,35 @@
 #' @param trajectory.group.by String denoting the name of a column of \code{data_frame} to use for generating trajectories from data point groups.
 #' @param trajectory.arrow.size Number representing the size of trajectory arrows, in inches.  Default = 0.15.
 #' @param add.trajectory.curves List of matrices, each representing coordinates for a trajectory path, from start to end, where matrix columns represent x and y coordinates of the paths.
-#' @param add.xline numeric value(s) where one or multiple vertical line(s) should be added.
+#' @param add.xline Numeric value(s) where one or multiple vertical line(s) should be added.
 #' @param xline.linetype String which sets the type of line for \code{add.xline}.
 #' Defaults to "dashed", but any ggplot linetype will work.
-#' @param xline.color String that sets the color(s) of the \code{add.xline} line(s).
-#' @param add.yline numeric value(s) where one or multiple vertical line(s) should be added.
+#' @param xline.color String that sets the color(s) of the \code{add.xline} line(s). Default = "black".
+#' Alternatively, a vector of strings of the same length as \code{add.xline} can be given to set the color of each line individually.
+#' @param xline.linewidth Number that sets the linewidth of the \code{add.xline} line(s). Default = 0.5.
+#' Alternatively, a vector of numbers of the same length as \code{add.xline} can be given to set the linewidth of each line individually.
+#' @param xline.opacity Number that sets the opacity of the \code{add.xline} line(s). Default = 1.
+#' Alternatively, a vector of numbers of the same length as \code{add.xline} can be given to set the opacity of each line individually.
+#' @param add.yline Numeric value(s) where one or multiple vertical line(s) should be added.
 #' @param yline.linetype String which sets the type of line for \code{add.yline}.
 #' Defaults to "dashed", but any ggplot linetype will work.
-#' @param yline.color String that sets the color(s) of the \code{add.yline} line(s).
+#' @param yline.color String that sets the color(s) of the \code{add.yline} line(s). Default = "black".
+#' Alternatively, a vector of strings of the same length as \code{add.yline} can be given to set the color of each line individually.
+#' @param yline.linewidth Number that sets the linewidth of the \code{add.yline} line(s). Default = 0.5.
+#' Alternatively, a vector of numbers of the same length as \code{add.yline} can be given to set the linewidth of each line individually.
+#' @param yline.opacity Number that sets the opacity of the \code{add.yline} line(s). Default = 1.
+#' Alternatively, a vector of numbers of the same length as \code{add.yline} can be given to set the opacity of each line individually.
+#' @param add.abline Numeric value(s) where one or multiple diagonal line(s) should be added.
+#' @param abline.slope Number that sets the slope of the \code{add.abline} line(s). Default = 1.
+#' Alternatively, a vector of numbers of the same length as \code{add.abline} can be given to set the slope of each line individually.
+#' @param abline.linetype String which sets the type of line for \code{add.abline}.
+#' Defaults to "dashed", but any ggplot linetype will work.
+#' @param abline.color String that sets the color(s) of the \code{add.abline} line(s). Default = "black".
+#' Alternatively, a vector of strings of the same length as \code{add.abline} can be given to set the color of each line individually.
+#' @param abline.linewidth Number that sets the linewidth of the \code{add.abline} line(s). Default = 0.5.
+#' Alternatively, a vector of numbers of the same length as \code{add.abline} can be given to set the linewidth of each line individually.
+#' @param abline.opacity Number that sets the opacity of the \code{add.abline} line(s). Default = 1.
+#' Alternatively, a vector of numbers of the same length as \code{add.abline} can be given to set the opacity of each line individually.
 #' @param theme A ggplot theme which will be applied before internal adjustments.
 #' Default = \code{theme_bw()}.
 #' See \url{https://ggplot2.tidyverse.org/reference/ggtheme.html} for other options and ideas.
@@ -162,7 +183,7 @@
 #' @seealso
 #' \code{\link{scatterHex}} for a hex-binned version that can be useful when points are very dense.
 #'
-#' @author Daniel Bunis
+#' @author Daniel Bunis, Jared Andrews
 #' @export
 #' @examples
 #' example("dittoExampleData", echo = FALSE)
@@ -317,9 +338,19 @@ scatterPlot <- function(
     add.xline = NULL,
     xline.linetype = "dashed",
     xline.color = "black",
+    xline.linewidth = 0.5,
+    xline.opacity = 1,
     add.yline = NULL,
     yline.linetype = "dashed",
     yline.color = "black",
+    yline.linewidth = 0.5,
+    yline.opacity = 1,
+    add.abline = NULL,
+    abline.slope = 1,
+    abline.linetype = "solid",
+    abline.color = "black",
+    abline.linewidth = 0.5,
+    abline.opacity = 1,
     do.letter = FALSE,
     do.ellipse = FALSE,
     do.label = FALSE,
@@ -383,14 +414,28 @@ scatterPlot <- function(
         legend.show, legend.color.title, legend.color.size,
         legend.color.breaks, legend.color.breaks.labels, legend.shape.title,
         legend.shape.size, do.raster, raster.dpi,
-        cols_use$split.by, split.show.all.others, show.grid.lines,
-        add.xline, xline.linetype, xline.color,
-        add.yline, yline.linetype, yline.color)
+        cols_use$split.by, split.show.all.others, show.grid.lines)
 
     ### Add extra features
     if (!is.null(cols_use$split.by)) {
         p <- .add_splitting(
             p, cols_use$split.by, split.nrow, split.ncol, split.adjust)
+    }
+
+    # Get number of panels so that replicates of aesthetics can be generated if supplied for each line.
+    pp <- ggplot_build(p)
+    num.panels <- length(levels(pp$data[[1]]$PANEL))
+
+    if (!is.null(add.xline)) {
+        p <- .add_xline(p, add.xline, xline.linetype, xline.color, xline.linewidth, xline.opacity, num.panels)
+    }
+
+    if (!is.null(add.yline)) {
+        p <- .add_yline(p, add.yline, yline.linetype, yline.color, yline.linewidth, yline.opacity, num.panels)
+    }
+
+    if (!is.null(add.abline)) {
+        p <- .add_abline(p, add.abline, abline.slope, abline.linetype, abline.color, abline.linewidth, abline.opacity, num.panels)
     }
 
     if (do.contour) {
@@ -467,13 +512,7 @@ scatterPlot <- function(
     raster.dpi,
     split.by,
     split.show.all.others,
-    show.grid.lines,
-    add.xline,
-    xline.linetype,
-    xline.color,
-    add.yline,
-    yline.linetype,
-    yline.color
+    show.grid.lines
 ) {
 
     ### Set up plotting
@@ -482,7 +521,7 @@ scatterPlot <- function(
             panel.grid.major = element_blank(),
             panel.grid.minor = element_blank())
     }
-    p <- ggplot() + ylab(ylab) + xlab(xlab) + ggtitle(main,sub) + theme
+    p <- ggplot() + ylab(ylab) + xlab(xlab) + ggtitle(main, sub) + theme
 
     # Determine how to add data while adding proper theming
     aes.use <- aes(x = .data[[x.by]], y = .data[[y.by]])
@@ -501,7 +540,7 @@ scatterPlot <- function(
         if (is.numeric(Target_data[,color.by])) {
             p <- p +
                 scale_colour_gradient(
-                    name = legend.color.title, low= min.color, high = max.color,
+                    name = legend.color.title, low = min.color, high = max.color,
                     limits = c(min.value, max.value),
                     breaks = legend.color.breaks,
                     labels = legend.color.breaks.labels)
@@ -562,14 +601,6 @@ scatterPlot <- function(
         } else {
             p <- p + do.call(geom_point, geom.args)
         }
-    }
-
-    if (!is.null(add.xline)) {
-        p <- p + geom_vline(xintercept = add.xline, linetype = xline.linetype, color = xline.color)
-    }
-
-    if (!is.null(add.yline)) {
-        p <- p + geom_hline(yintercept = add.yline, linetype = yline.linetype, color = yline.color)
     }
 
     if (!legend.show) {

--- a/R/scatterPlot.R
+++ b/R/scatterPlot.R
@@ -105,7 +105,7 @@
 #' @param trajectory.group.by String denoting the name of a column of \code{data_frame} to use for generating trajectories from data point groups.
 #' @param trajectory.arrow.size Number representing the size of trajectory arrows, in inches.  Default = 0.15.
 #' @param add.trajectory.curves List of matrices, each representing coordinates for a trajectory path, from start to end, where matrix columns represent x and y coordinates of the paths.
-#' @param add.xline Numeric value(s) where one or multiple vertical line(s) should be added.
+#' @param add.xline Numeric value(s), denoting x-axis value(s), where one or more vertical line(s) should be added.
 #' @param xline.linetype String which sets the type of line for \code{add.xline}.
 #' Defaults to "dashed", but any ggplot linetype will work.
 #' @param xline.color String that sets the color(s) of the \code{add.xline} line(s). Default = "black".
@@ -114,7 +114,7 @@
 #' Alternatively, a vector of numbers of the same length as \code{add.xline} can be given to set the linewidth of each line individually.
 #' @param xline.opacity Number that sets the opacity of the \code{add.xline} line(s). Default = 1.
 #' Alternatively, a vector of numbers of the same length as \code{add.xline} can be given to set the opacity of each line individually.
-#' @param add.yline Numeric value(s) where one or multiple vertical line(s) should be added.
+#' @param add.yline Numeric value(s), denoting y-axis value(s), where one or multiple horizonal line(s) should be added.
 #' @param yline.linetype String which sets the type of line for \code{add.yline}.
 #' Defaults to "dashed", but any ggplot linetype will work.
 #' @param yline.color String that sets the color(s) of the \code{add.yline} line(s). Default = "black".
@@ -123,7 +123,8 @@
 #' Alternatively, a vector of numbers of the same length as \code{add.yline} can be given to set the linewidth of each line individually.
 #' @param yline.opacity Number that sets the opacity of the \code{add.yline} line(s). Default = 1.
 #' Alternatively, a vector of numbers of the same length as \code{add.yline} can be given to set the opacity of each line individually.
-#' @param add.abline Numeric value(s) where one or multiple diagonal line(s) should be added.
+#' @param add.abline Numeric value(s), denoting y-axis intercept(s), where one or multiple diagonal line(s) should be added.
+#' Use \code{abline.slope} to set slope(s).
 #' @param abline.slope Number that sets the slope of the \code{add.abline} line(s). Default = 1.
 #' Alternatively, a vector of numbers of the same length as \code{add.abline} can be given to set the slope of each line individually.
 #' @param abline.linetype String which sets the type of line for \code{add.abline}.

--- a/R/scatterPlot.R
+++ b/R/scatterPlot.R
@@ -69,7 +69,7 @@
 #' @param do.label  Logical. Whether to add text labels near the center (median) of \code{color.by} groups.
 #' @param labels.size Number which sets the size of labels text when \code{do.label = TRUE}.
 #' @param labels.highlight Logical. Whether labels should have a box behind them when \code{do.label = TRUE}.
-#' @param labels.repel Logical, that sets whether the labels' placements will be adjusted with \link{ggrepel} to avoid intersections between labels and plot bounds when \code{do.label = TRUE}.
+#' @param labels.repel Logical, that sets whether the labels' placements will be adjusted with \link[ggrepel]{ggrepel} to avoid intersections between labels and plot bounds when \code{do.label = TRUE}.
 #' TRUE by default.
 #' @param labels.split.by String of one or two column names which controls the facet-split calculations for label placements.
 #' Defaults to \code{split.by}, so generally there is no need to adjust this except when if you plan to apply faceting externally.

--- a/R/utils_plot_mods.R
+++ b/R/utils_plot_mods.R
@@ -1,5 +1,4 @@
 .add_splitting <- function(p, split.by, nrow, ncol, split.args) {
-
     # Adds ggplot faceting to go with 'split.by' utilization.
 
     # When split.by is length 1, the shape is controlled with ncol & nrow
@@ -37,20 +36,20 @@
     labels.repel.adjust, labels.use.numbers, labels.numbers.spacer,
     legend.color.title,
     letter.size, letter.opacity, letter.legend.title, letter.legend.size) {
-
-    if (!is.numeric(data[,color.by])) {
-
+    if (!is.numeric(data[, color.by])) {
         if (do.letter) {
             p <- .add_letters(
                 p, data, x.by, y.by, color.by,
-                letter.size, letter.opacity, letter.legend.title, letter.legend.size)
+                letter.size, letter.opacity, letter.legend.title, letter.legend.size
+            )
         }
 
         if (do.ellipse) {
             p <- p + stat_ellipse(
-                data=data,
+                data = data,
                 aes(x = .data[[x.by]], y = .data[[y.by]], colour = .data[[color.by]]),
-                type = "t", linetype = 2, linewidth = 0.5, show.legend = FALSE, na.rm = TRUE)
+                type = "t", linetype = 2, linewidth = 0.5, show.legend = FALSE, na.rm = TRUE
+            )
         }
 
         if (do.label) {
@@ -60,16 +59,16 @@
                 labels.repel.adjust, labels.use.numbers, labels.numbers.spacer,
                 legend.color.title)
         }
-
     } else {
-
         # Data is incompatible, so message instead of adding.
         ignored.targs <- paste(
-            c("do.letter", "do.ellipse", "do.label")[c(do.letter,do.ellipse,do.label)],
-            collapse = ", ")
+            c("do.letter", "do.ellipse", "do.label")[c(do.letter, do.ellipse, do.label)],
+            collapse = ", "
+        )
         .msg_if(
             do.letter || do.ellipse || do.label,
-            ignored.targs, " was/were ignored for non-discrete data.")
+            ignored.targs, " was/were ignored for non-discrete data."
+        )
     }
 
     p
@@ -85,7 +84,8 @@
         mapping = aes(x = .data[[x.by]], y = .data[[y.by]]),
         color = color,
         linetype = linetype,
-        na.rm = TRUE)
+        na.rm = TRUE
+    )
 }
 
 #' @importFrom stats setNames
@@ -100,16 +100,12 @@
 
     # Determine medians
     if (is.null(split.by)) {
-
         median.data <- .calc_xy_medians(Target_data, labels.by, x.by, y.by)
-
-    } else if (length(split.by)==1) {
-
+    } else if (length(split.by) == 1) {
         median.data <- NULL
 
-        for (level in levels(as.factor(as.character(Target_data[,split.by])))) {
-
-            level.dat <- Target_data[Target_data[,split.by]==level,]
+        for (level in levels(as.factor(as.character(Target_data[, split.by])))) {
+            level.dat <- Target_data[Target_data[, split.by] == level, ]
 
             level.med.dat <- .calc_xy_medians(level.dat, labels.by, x.by, y.by)
             # Add split.by columns
@@ -120,20 +116,19 @@
         }
 
         # Ensure retention of factor level ordering
-        median.data[,split.by] <- .retain_factor_level_order(
-            median.data[,split.by], possible_factor = Target_data[,split.by])
-
-    } else if (length(split.by)==2) {
-
+        median.data[, split.by] <- .retain_factor_level_order(
+            median.data[, split.by],
+            possible_factor = Target_data[, split.by]
+        )
+    } else if (length(split.by) == 2) {
         median.data <- NULL
 
-        for (level1 in levels(as.factor(as.character(Target_data[,split.by[1]])))) {
-            for (level2 in levels(as.factor(as.character(Target_data[,split.by[2]])))) {
+        for (level1 in levels(as.factor(as.character(Target_data[, split.by[1]])))) {
+            for (level2 in levels(as.factor(as.character(Target_data[, split.by[2]])))) {
+                level.dat <- Target_data[Target_data[, split.by[1]] == level1, ]
+                level.dat <- level.dat[level.dat[, split.by[2]] == level2, ]
 
-                level.dat <- Target_data[Target_data[,split.by[1]]==level1,]
-                level.dat <- level.dat[level.dat[,split.by[2]]==level2,]
-
-                if (nrow(level.dat)>0) {
+                if (nrow(level.dat) > 0) {
                     level.med.dat <- .calc_xy_medians(level.dat, labels.by, x.by, y.by)
                     # Add split.by columns
                     level.med.dat$split1 <- level1
@@ -146,10 +141,14 @@
         }
 
         # Ensure retention of factor level ordering
-        median.data[,split.by[1]] <- .retain_factor_level_order(
-            median.data[,split.by[1]], possible_factor = Target_data[,split.by[1]])
-        median.data[,split.by[2]] <- .retain_factor_level_order(
-            median.data[,split.by[2]], possible_factor = Target_data[,split.by[2]])
+        median.data[, split.by[1]] <- .retain_factor_level_order(
+            median.data[, split.by[1]],
+            possible_factor = Target_data[, split.by[1]]
+        )
+        median.data[, split.by[2]] <- .retain_factor_level_order(
+            median.data[, split.by[2]],
+            possible_factor = Target_data[, split.by[2]]
+        )
     }
 
     if (labels.use.numbers) {
@@ -183,7 +182,8 @@
     args <- list(
         data = median.data,
         mapping = aes(x = .data$cent.x, y = .data$cent.y, label = .data$label),
-        size = labels.size)
+        size = labels.size
+    )
     if (labels.repel) {
         if (is.list(labels.repel.adjust)) {
             args <- c(args, labels.repel.adjust)
@@ -213,19 +213,24 @@
 }
 
 .calc_xy_medians <- function(x.y.group.df, group.col, x.by, y.by) {
-    groups <- levels(as.factor(as.character(x.y.group.df[,group.col])))
+    groups <- levels(as.factor(as.character(x.y.group.df[, group.col])))
     data.frame(
         cent.x = vapply(
             groups,
             function(level) {
-                median(x.y.group.df[x.y.group.df[,group.col]==level, x.by], na.rm = TRUE)
-            }, FUN.VALUE = numeric(1)),
+                median(x.y.group.df[x.y.group.df[, group.col] == level, x.by], na.rm = TRUE)
+            },
+            FUN.VALUE = numeric(1)
+        ),
         cent.y = vapply(
             groups,
             function(level) {
-                median(x.y.group.df[x.y.group.df[,group.col]==level, y.by], na.rm = TRUE)
-            }, FUN.VALUE = numeric(1)),
-        label = groups)
+                median(x.y.group.df[x.y.group.df[, group.col] == level, y.by], na.rm = TRUE)
+            },
+            FUN.VALUE = numeric(1)
+        ),
+        label = groups
+    )
 }
 
 .add_trajectories_by_groups <- function(
@@ -243,13 +248,15 @@
     cluster.levels <- colLevels(group.by, data)
     group_medians <- .calc_xy_medians(data, group.by, x.by, y.by)
 
-    #Add trajectories
-    for (i in seq_along(trajectories)){
+    # Add trajectories
+    for (i in seq_along(trajectories)) {
         p <- p + geom_path(
-            data = group_medians[as.character(trajectories[[i]]),],
+            data = group_medians[as.character(trajectories[[i]]), ],
             aes(x = .data$cent.x, y = .data$cent.y),
             arrow = arrow(
-                angle = 20, type = "closed", length = unit(arrow.size, "inches")))
+                angle = 20, type = "closed", length = unit(arrow.size, "inches")
+            )
+        )
     }
     p
 }
@@ -271,7 +278,9 @@
             data = data,
             aes(x = .data$x, y = .data$y),
             arrow = arrow(
-                angle = 20, type = "closed", length = unit(arrow.size, "inches")))
+                angle = 20, type = "closed", length = unit(arrow.size, "inches")
+            )
+        )
     }
     p
 }
@@ -283,19 +292,132 @@
     # Color blindness aid
     # (Dim and Scatter plots)
 
-    letters.needed <- length(levels(as.factor(Target_data[,col.use])))
+    letters.needed <- length(levels(as.factor(Target_data[, col.use])))
     letter.labels <- c(
         LETTERS, letters, 0:9, "!", "@", "#", "$", "%", "^", "&", "*", "(",
         ")", "-", "+", "_", "=", ";", "/", "|", "{", "}", "~"
     )[seq_len(letters.needed)]
-    names(letter.labels) <- levels(as.factor(Target_data[,col.use]))
+    names(letter.labels) <- levels(as.factor(Target_data[, col.use]))
     p <- p +
         geom_point(
-            data=Target_data,
+            data = Target_data,
             aes(x = .data[[x.by]], y = .data[[y.by]], shape = .data[[col.use]]),
-            color = "black", size=size*3/4, alpha = opacity) +
+            color = "black", size = size * 3 / 4, alpha = opacity
+        ) +
         scale_shape_manual(
             name = legend.title,
-            values = letter.labels)
+            values = letter.labels
+        )
     p
+}
+
+.add_xline <- function(p, add.xline, xline.linetype, xline.color, xline.linewidth, xline.opacity, num.panels) {
+    
+    if (length(xline.linetype) != length(add.xline) & length(xline.linetype) != 1) {
+        warning("xline.linetype must be length 1 or the same length as add.xline, setting to first provided value")
+        xline.linetype <- xline.linetype[1]
+    } else if (length(xline.linetype) != 1) {
+        xline.linetype <- rep(xline.linetype, num.panels)
+    }
+
+    if (length(xline.color) != length(add.xline) & length(xline.color) != 1) {
+        warning("xline.color must be length 1 or the same length as add.xline, setting to first provided value")
+        xline.color <- xline.color[1]
+    } else if (length(xline.color) != 1) {
+        xline.color <- rep(xline.color, num.panels)
+    }
+
+    if (length(xline.linewidth) != length(add.xline) & length(xline.linewidth) != 1) {
+        warning("xline.linewidth must be length 1 or the same length as add.xline, setting to first provided value")
+        xline.linewidth <- xline.linewidth[1]
+    } else if (length(xline.linewidth) != 1) {
+        xline.linewidth <- rep(xline.linewidth, num.panels)
+    }
+
+    if (length(xline.opacity) != length(add.xline) & length(xline.opacity) != 1) {
+        warning("xline.opacity must be length 1 or the same length as add.xline, setting to first provided value")
+        xline.opacity <- xline.opacity[1]
+    } else if (length(xline.opacity) != 1) {
+        xline.opacity <- rep(xline.opacity, num.panels)
+    }
+
+    p + geom_vline(
+        xintercept = add.xline, linetype = xline.linetype, color = xline.color,
+        linewidth = xline.linewidth, alpha = xline.opacity
+    )
+}
+
+.add_yline <- function(p, add.yline, yline.linetype, yline.color, yline.linewidth, yline.opacity, num.panels) {
+    if (length(yline.linetype) != length(add.yline) & length(yline.linetype) != 1) {
+        warning("yline.linetype must be length 1 or the same length as add.yline, setting to first provided value")
+        yline.linetype <- yline.linetype[1]
+    } else if (length(yline.linetype) != 1) {
+        yline.linetype <- rep(yline.linetype, num.panels)
+    }
+
+    if (length(yline.color) != length(add.yline) & length(yline.color) != 1) {
+        warning("yline.color must be length 1 or the same length as add.yline, setting to first provided value")
+        yline.color <- yline.color[1]
+    } else if (length(yline.color) != 1) {
+        yline.color <- rep(yline.color, num.panels)
+    }
+
+    if (length(yline.linewidth) != length(add.yline) & length(yline.linewidth) != 1) {
+        warning("yline.linewidth must be length 1 or the same length as add.yline, setting to first provided value")
+        yline.linewidth <- yline.linewidth[1]
+    } else if (length(yline.linewidth) != 1) {
+        yline.linewidth <- rep(yline.linewidth, num.panels)
+    }
+
+    if (length(yline.opacity) != length(add.yline) & length(yline.opacity) != 1) {
+        warning("yline.opacity must be length 1 or the same length as add.yline, setting to first provided value")
+        yline.opacity <- yline.opacity[1]
+    } else if (length(yline.opacity) != 1) {
+        yline.opacity <- rep(yline.opacity, num.panels)
+    }
+
+    p + geom_hline(
+        yintercept = add.yline, linetype = yline.linetype, color = yline.color,
+        linewidth = yline.linewidth, alpha = yline.opacity
+    )
+}
+
+.add_abline <- function(p, add.abline, abline.slope, abline.linetype, abline.color, abline.linewidth, abline.opacity, num.panels) {
+    if (length(abline.slope) != length(add.abline) & length(abline.slope) != 1) {
+        warning("abline.slope must be length 1 or the same length as add.abline, setting to first provided value")
+        abline.slope <- abline.slope[1]
+    } 
+    
+    if (length(abline.linetype) != length(add.abline) & length(abline.linetype) != 1) {
+        warning("abline.linetype must be length 1 or the same length as add.abline, setting to first provided value")
+        abline.linetype <- abline.linetype[1]
+    } else if (length(abline.linetype) != 1) {
+        abline.linetype <- rep(abline.linetype, num.panels)
+    }
+
+    if (length(abline.color) != length(add.abline) & length(abline.color) != 1) {
+        warning("abline.color must be length 1 or the same length as add.abline, setting to first provided value")
+        abline.color <- abline.color[1]
+    } else if (length(abline.color) != 1) {
+        abline.color <- rep(abline.color, num.panels)
+    }
+
+    if (length(abline.linewidth) != length(add.abline) & length(abline.linewidth) != 1) {
+        warning("abline.linewidth must be length 1 or the same length as add.abline, setting to first provided value")
+        abline.linewidth <- abline.linewidth[1]
+    } else if (length(abline.linewidth) != 1) {
+        abline.linewidth <- rep(abline.linewidth, num.panels)
+    }
+
+    if (length(abline.opacity) != length(add.abline) & length(abline.opacity) != 1) {
+        warning("abline.opacity must be length 1 or the same length as add.abline, setting to first provided value")
+        abline.opacity <- abline.opacity[1]
+    } else if (length(abline.opacity) != 1) {
+        abline.opacity <- rep(abline.opacity, num.panels)
+    }
+
+    p + geom_abline(
+        intercept = add.abline, slope = abline.slope, linetype = abline.linetype, color = abline.color,
+        linewidth = abline.linewidth, alpha = abline.opacity
+    )
 }

--- a/R/utils_plot_mods.R
+++ b/R/utils_plot_mods.R
@@ -311,35 +311,32 @@
     p
 }
 
+
+# Checks wrapper for .add_*line functions
+._ensure_lengths_and_adjust_for_panels <- function(
+        add.line, add.line.name,
+        line.param, line.param.name,
+        num.panels
+) {
+    if (length(line.param) != length(add.line) & length(line.param) != 1) {
+        warning("'", line.param.name, "' must be length 1 or the same length as '", add.line.name, "', using only the first provided value.")
+        line.param[1]
+    } else if (length(line.param) != 1) {
+        rep(line.param, num.panels)
+    } else {
+        line.param
+    }
+}
+
 .add_xline <- function(p, add.xline, xline.linetype, xline.color, xline.linewidth, xline.opacity, num.panels) {
-    
-    if (length(xline.linetype) != length(add.xline) & length(xline.linetype) != 1) {
-        warning("xline.linetype must be length 1 or the same length as add.xline, setting to first provided value")
-        xline.linetype <- xline.linetype[1]
-    } else if (length(xline.linetype) != 1) {
-        xline.linetype <- rep(xline.linetype, num.panels)
-    }
 
-    if (length(xline.color) != length(add.xline) & length(xline.color) != 1) {
-        warning("xline.color must be length 1 or the same length as add.xline, setting to first provided value")
-        xline.color <- xline.color[1]
-    } else if (length(xline.color) != 1) {
-        xline.color <- rep(xline.color, num.panels)
+    ._elafp <- function(l.p, l.p.n) {
+        ._ensure_lengths_and_adjust_for_panels(add.xline, "add.xline", l.p, l.p.n, num.panels)
     }
-
-    if (length(xline.linewidth) != length(add.xline) & length(xline.linewidth) != 1) {
-        warning("xline.linewidth must be length 1 or the same length as add.xline, setting to first provided value")
-        xline.linewidth <- xline.linewidth[1]
-    } else if (length(xline.linewidth) != 1) {
-        xline.linewidth <- rep(xline.linewidth, num.panels)
-    }
-
-    if (length(xline.opacity) != length(add.xline) & length(xline.opacity) != 1) {
-        warning("xline.opacity must be length 1 or the same length as add.xline, setting to first provided value")
-        xline.opacity <- xline.opacity[1]
-    } else if (length(xline.opacity) != 1) {
-        xline.opacity <- rep(xline.opacity, num.panels)
-    }
+    xline.linetype <- ._elafp(xline.linetype, "xline.linetype")
+    xline.color <- ._elafp(xline.color, "xline.color")
+    xline.linewidth <- ._elafp(xline.linewidth, "xline.linewidth")
+    xline.opacity <- ._elafp(xline.opacity, "xline.opacity")
 
     p + geom_vline(
         xintercept = add.xline, linetype = xline.linetype, color = xline.color,
@@ -348,33 +345,14 @@
 }
 
 .add_yline <- function(p, add.yline, yline.linetype, yline.color, yline.linewidth, yline.opacity, num.panels) {
-    if (length(yline.linetype) != length(add.yline) & length(yline.linetype) != 1) {
-        warning("yline.linetype must be length 1 or the same length as add.yline, setting to first provided value")
-        yline.linetype <- yline.linetype[1]
-    } else if (length(yline.linetype) != 1) {
-        yline.linetype <- rep(yline.linetype, num.panels)
-    }
 
-    if (length(yline.color) != length(add.yline) & length(yline.color) != 1) {
-        warning("yline.color must be length 1 or the same length as add.yline, setting to first provided value")
-        yline.color <- yline.color[1]
-    } else if (length(yline.color) != 1) {
-        yline.color <- rep(yline.color, num.panels)
+    ._elafp <- function(l.p, l.p.n) {
+        ._ensure_lengths_and_adjust_for_panels(add.yline, "add.yline", l.p, l.p.n, num.panels)
     }
-
-    if (length(yline.linewidth) != length(add.yline) & length(yline.linewidth) != 1) {
-        warning("yline.linewidth must be length 1 or the same length as add.yline, setting to first provided value")
-        yline.linewidth <- yline.linewidth[1]
-    } else if (length(yline.linewidth) != 1) {
-        yline.linewidth <- rep(yline.linewidth, num.panels)
-    }
-
-    if (length(yline.opacity) != length(add.yline) & length(yline.opacity) != 1) {
-        warning("yline.opacity must be length 1 or the same length as add.yline, setting to first provided value")
-        yline.opacity <- yline.opacity[1]
-    } else if (length(yline.opacity) != 1) {
-        yline.opacity <- rep(yline.opacity, num.panels)
-    }
+    yline.linetype <- ._elafp(yline.linetype, "yline.linetype")
+    yline.color <- ._elafp(yline.color, "yline.color")
+    yline.linewidth <- ._elafp(yline.linewidth, "yline.linewidth")
+    yline.opacity <- ._elafp(yline.opacity, "yline.opacity")
 
     p + geom_hline(
         yintercept = add.yline, linetype = yline.linetype, color = yline.color,
@@ -383,37 +361,17 @@
 }
 
 .add_abline <- function(p, add.abline, abline.slope, abline.linetype, abline.color, abline.linewidth, abline.opacity, num.panels) {
+
+    ._elafp <- function(l.p, l.p.n) {
+        ._ensure_lengths_and_adjust_for_panels(add.abline, "add.abline", l.p, l.p.n, num.panels)
+    }
+    abline.linetype <- ._elafp(abline.linetype, "abline.linetype")
+    abline.color <- ._elafp(abline.color, "abline.color")
+    abline.linewidth <- ._elafp(abline.linewidth, "abline.linewidth")
+    abline.opacity <- ._elafp(abline.opacity, "abline.opacity")
     if (length(abline.slope) != length(add.abline) & length(abline.slope) != 1) {
-        warning("abline.slope must be length 1 or the same length as add.abline, setting to first provided value")
+        warning("'abline.slope' must be length 1 or the same length as 'add.abline', using only the first provided value.")
         abline.slope <- abline.slope[1]
-    } 
-    
-    if (length(abline.linetype) != length(add.abline) & length(abline.linetype) != 1) {
-        warning("abline.linetype must be length 1 or the same length as add.abline, setting to first provided value")
-        abline.linetype <- abline.linetype[1]
-    } else if (length(abline.linetype) != 1) {
-        abline.linetype <- rep(abline.linetype, num.panels)
-    }
-
-    if (length(abline.color) != length(add.abline) & length(abline.color) != 1) {
-        warning("abline.color must be length 1 or the same length as add.abline, setting to first provided value")
-        abline.color <- abline.color[1]
-    } else if (length(abline.color) != 1) {
-        abline.color <- rep(abline.color, num.panels)
-    }
-
-    if (length(abline.linewidth) != length(add.abline) & length(abline.linewidth) != 1) {
-        warning("abline.linewidth must be length 1 or the same length as add.abline, setting to first provided value")
-        abline.linewidth <- abline.linewidth[1]
-    } else if (length(abline.linewidth) != 1) {
-        abline.linewidth <- rep(abline.linewidth, num.panels)
-    }
-
-    if (length(abline.opacity) != length(add.abline) & length(abline.opacity) != 1) {
-        warning("abline.opacity must be length 1 or the same length as add.abline, setting to first provided value")
-        abline.opacity <- abline.opacity[1]
-    } else if (length(abline.opacity) != 1) {
-        abline.opacity <- rep(abline.opacity, num.panels)
     }
 
     p + geom_abline(

--- a/R/yPlot.R
+++ b/R/yPlot.R
@@ -109,7 +109,7 @@
 #' @param vlnplot.width Scalar which sets the width/spread of violin plots in the x direction
 #' @param vlnplot.scaling String which sets how the widths of the of violin plots are set in relation to each other.
 #' Options are "area", "count", and "width". If the default is not right for your data, I recommend trying "width".
-#' For an explanation of each, see \code{\link{geom_violin}}.
+#' For an explanation of each, see \code{\link[ggplot2]{geom_violin}}.
 #' @param vlnplot.quantiles Single number or numeric vector of values in [0,1] naming quantiles at which to draw a horizontal line within each violin plot. Example: \code{c(0.1, 0.5, 0.9)}
 #' @param ridgeplot.lineweight Scalar which sets the thickness of the ridgeplot outline.
 #' @param ridgeplot.scale Scalar which sets the distance/overlap between ridgeplots.
@@ -408,7 +408,7 @@ yPlot <- function(
             plots, xlab, ylab, jitter.size, jitter.color,
             jitter.shape.legend.size, jitter.shape.legend.show,
             ridgeplot.lineweight, ridgeplot.scale, ridgeplot.ymax.expansion,
-            ridgeplot.shape, ridgeplot.bins, ridgeplot.binwidth, 
+            ridgeplot.shape, ridgeplot.bins, ridgeplot.binwidth,
             x.labels.rotate, do.hover, color.panel,
             colors, y.breaks, min, max)
     }

--- a/R/yPlot.R
+++ b/R/yPlot.R
@@ -72,7 +72,7 @@
 #' is to make the target data into a factor, and to put its levels in the desired order: \code{factor(data, levels = c("level1", "level2", ...))}.
 #' @param x.labels.rotate Logical which sets whether the labels should be rotated.
 #' Default: \code{TRUE} for violin and box plots, but \code{FALSE} for ridgeplots.
-#' @param add.line Numeric value(s) where one or multiple line(s) should be added.
+#' @param add.line Numeric value(s), denoting y-axis value(s), where one or multiple horizonal line(s) should be added.
 #' @param line.linetype String which sets the type of line for \code{add.line}.
 #' Defaults to "dashed", but any ggplot linetype will work.
 #' @param line.color String that sets the color(s) of the \code{add.line} line(s). Default = "black".

--- a/man/barPlot.Rd
+++ b/man/barPlot.Rd
@@ -35,7 +35,12 @@ barPlot(
   main = "make",
   sub = NULL,
   legend.show = TRUE,
-  legend.title = NULL
+  legend.title = NULL,
+  add.line = NULL,
+  line.linetype = "dashed",
+  line.color = "black",
+  line.linewidth = 0.5,
+  line.opacity = 1
 )
 }
 \arguments{
@@ -135,6 +140,20 @@ Default = "make" and if left as make, a title will be automatically generated.}
 \item{legend.show}{Logical. Whether the legend should be displayed. Default = \code{TRUE}.}
 
 \item{legend.title}{String which adds a title to the legend.}
+
+\item{add.line}{Numeric value(s) where one or multiple line(s) should be added.}
+
+\item{line.linetype}{String which sets the type of line for \code{add.line}.
+Defaults to "dashed", but any ggplot linetype will work.}
+
+\item{line.color}{String that sets the color(s) of the \code{add.line} line(s). Default = "black".
+Alternatively, a vector of strings of the same length as \code{add.line} can be given to set the color of each line individually.}
+
+\item{line.linewidth}{Number that sets the linewidth of the \code{add.line} line(s). Default = 0.5.
+Alternatively, a vector of numbers of the same length as \code{add.line} can be given to set the linewidth of each line individually.}
+
+\item{line.opacity}{Number that sets the opacity of the \code{add.line} line(s). Default = 1.
+Alternatively, a vector of numbers of the same length as \code{add.line} can be given to set the opacity of each line individually.}
 }
 \value{
 A ggplot plot where discrete data, grouped by sample, condition, cluster, etc. on the x-axis, is shown on the y-axis as either counts or percent-of-total-per-grouping in a stacked barplot.

--- a/man/barPlot.Rd
+++ b/man/barPlot.Rd
@@ -141,7 +141,7 @@ Default = "make" and if left as make, a title will be automatically generated.}
 
 \item{legend.title}{String which adds a title to the legend.}
 
-\item{add.line}{Numeric value(s) where one or multiple line(s) should be added.}
+\item{add.line}{Numeric value(s), denoting y-axis value(s), where one or multiple horizonal line(s) should be added.}
 
 \item{line.linetype}{String which sets the type of line for \code{add.line}.
 Defaults to "dashed", but any ggplot linetype will work.}

--- a/man/freqPlot.Rd
+++ b/man/freqPlot.Rd
@@ -239,7 +239,7 @@ Overridden by \code{ridgeplot.binwidth} when that input is provided.}
 \item{ridgeplot.binwidth}{Integer which sets the width of chunks to break the x-axis into when \code{ridgeplot.shape = "hist"}.
 Takes precedence over \code{ridgeplot.bins} when provided.}
 
-\item{add.line}{Numeric value(s) where one or multiple line(s) should be added.}
+\item{add.line}{Numeric value(s), denoting y-axis value(s), where one or multiple horizonal line(s) should be added.}
 
 \item{line.linetype}{String which sets the type of line for \code{add.line}.
 Defaults to "dashed", but any ggplot linetype will work.}

--- a/man/freqPlot.Rd
+++ b/man/freqPlot.Rd
@@ -63,6 +63,8 @@ freqPlot(
   add.line = NULL,
   line.linetype = "dashed",
   line.color = "black",
+  line.linewidth = 0.5,
+  line.opacity = 1,
   legend.show = TRUE,
   legend.title = color.by
 )
@@ -237,12 +239,19 @@ Overridden by \code{ridgeplot.binwidth} when that input is provided.}
 \item{ridgeplot.binwidth}{Integer which sets the width of chunks to break the x-axis into when \code{ridgeplot.shape = "hist"}.
 Takes precedence over \code{ridgeplot.bins} when provided.}
 
-\item{add.line}{numeric value(s) where one or multiple line(s) should be added}
+\item{add.line}{Numeric value(s) where one or multiple line(s) should be added.}
 
 \item{line.linetype}{String which sets the type of line for \code{add.line}.
 Defaults to "dashed", but any ggplot linetype will work.}
 
-\item{line.color}{String that sets the color(s) of the \code{add.line} line(s)}
+\item{line.color}{String that sets the color(s) of the \code{add.line} line(s). Default = "black".
+Alternatively, a vector of strings of the same length as \code{add.line} can be given to set the color of each line individually.}
+
+\item{line.linewidth}{Number that sets the linewidth of the \code{add.line} line(s). Default = 0.5.
+Alternatively, a vector of numbers of the same length as \code{add.line} can be given to set the linewidth of each line individually.}
+
+\item{line.opacity}{Number that sets the opacity of the \code{add.line} line(s). Default = 1.
+Alternatively, a vector of numbers of the same length as \code{add.line} can be given to set the opacity of each line individually.}
 
 \item{legend.show}{Logical. Whether the legend should be displayed. Default = \code{TRUE}.}
 

--- a/man/freqPlot.Rd
+++ b/man/freqPlot.Rd
@@ -216,7 +216,7 @@ By default, this input actually controls the value of \code{jitter.position.dodg
 
 \item{vlnplot.scaling}{String which sets how the widths of the of violin plots are set in relation to each other.
 Options are "area", "count", and "width". If the default is not right for your data, I recommend trying "width".
-For an explanation of each, see \code{\link{geom_violin}}.}
+For an explanation of each, see \code{\link[ggplot2]{geom_violin}}.}
 
 \item{vlnplot.quantiles}{Single number or numeric vector of values in [0,1] naming quantiles at which to draw a horizontal line within each violin plot. Example: \code{c(0.1, 0.5, 0.9)}}
 

--- a/man/scatterHex.Rd
+++ b/man/scatterHex.Rd
@@ -58,9 +58,19 @@ scatterHex(
   add.xline = NULL,
   xline.linetype = "dashed",
   xline.color = "black",
+  xline.linewidth = 0.5,
+  xline.opacity = 1,
   add.yline = NULL,
   yline.linetype = "dashed",
   yline.color = "black",
+  yline.linewidth = 0.5,
+  yline.opacity = 1,
+  add.abline = NULL,
+  abline.slope = 1,
+  abline.linetype = "solid",
+  abline.color = "black",
+  abline.linewidth = 0.5,
+  abline.opacity = 1,
   legend.show = TRUE,
   legend.color.title = "make",
   legend.color.breaks = waiver(),
@@ -203,19 +213,50 @@ List elements should be valid inputs to the \code{\link[ggrepel]{geom_label_repe
 
 \item{trajectory.arrow.size}{Number representing the size of trajectory arrows, in inches.  Default = 0.15.}
 
-\item{add.xline}{numeric value(s) where one or multiple vertical line(s) should be added.}
+\item{add.xline}{Numeric value(s) where one or multiple vertical line(s) should be added.}
 
 \item{xline.linetype}{String which sets the type of line for \code{add.xline}.
 Defaults to "dashed", but any ggplot linetype will work.}
 
-\item{xline.color}{String that sets the color(s) of the \code{add.xline} line(s).}
+\item{xline.color}{String that sets the color(s) of the \code{add.xline} line(s). Default = "black".
+Alternatively, a vector of strings of the same length as \code{add.xline} can be given to set the color of each line individually.}
 
-\item{add.yline}{numeric value(s) where one or multiple vertical line(s) should be added.}
+\item{xline.linewidth}{Number that sets the linewidth of the \code{add.xline} line(s). Default = 0.5.
+Alternatively, a vector of numbers of the same length as \code{add.xline} can be given to set the linewidth of each line individually.}
+
+\item{xline.opacity}{Number that sets the opacity of the \code{add.xline} line(s). Default = 1.
+Alternatively, a vector of numbers of the same length as \code{add.xline} can be given to set the opacity of each line individually.}
+
+\item{add.yline}{Numeric value(s) where one or multiple vertical line(s) should be added.}
 
 \item{yline.linetype}{String which sets the type of line for \code{add.yline}.
 Defaults to "dashed", but any ggplot linetype will work.}
 
-\item{yline.color}{String that sets the color(s) of the \code{add.yline} line(s).}
+\item{yline.color}{String that sets the color(s) of the \code{add.yline} line(s). Default = "black".
+Alternatively, a vector of strings of the same length as \code{add.yline} can be given to set the color of each line individually.}
+
+\item{yline.linewidth}{Number that sets the linewidth of the \code{add.yline} line(s). Default = 0.5.
+Alternatively, a vector of numbers of the same length as \code{add.yline} can be given to set the linewidth of each line individually.}
+
+\item{yline.opacity}{Number that sets the opacity of the \code{add.yline} line(s). Default = 1.
+Alternatively, a vector of numbers of the same length as \code{add.yline} can be given to set the opacity of each line individually.}
+
+\item{add.abline}{Numeric value(s) where one or multiple diagonal line(s) should be added.}
+
+\item{abline.slope}{Number that sets the slope of the \code{add.abline} line(s). Default = 1.
+Alternatively, a vector of numbers of the same length as \code{add.abline} can be given to set the slope of each line individually.}
+
+\item{abline.linetype}{String which sets the type of line for \code{add.abline}.
+Defaults to "dashed", but any ggplot linetype will work.}
+
+\item{abline.color}{String that sets the color(s) of the \code{add.abline} line(s). Default = "black".
+Alternatively, a vector of strings of the same length as \code{add.abline} can be given to set the color of each line individually.}
+
+\item{abline.linewidth}{Number that sets the linewidth of the \code{add.abline} line(s). Default = 0.5.
+Alternatively, a vector of numbers of the same length as \code{add.abline} can be given to set the linewidth of each line individually.}
+
+\item{abline.opacity}{Number that sets the opacity of the \code{add.abline} line(s). Default = 1.
+Alternatively, a vector of numbers of the same length as \code{add.abline} can be given to set the opacity of each line individually.}
 
 \item{legend.show}{Logical. Whether any legend should be displayed. Default = \code{TRUE}.}
 
@@ -423,5 +464,5 @@ out$cols_use
 It is often best to investigate your data with both the individual and hex-bin methods, then pick whichever is the best representation for your particular goal.
 }
 \author{
-Daniel Bunis with some code adapted from Giuseppe D'Agostino
+Daniel Bunis, Jared Andrews with some code adapted from Giuseppe D'Agostino
 }

--- a/man/scatterHex.Rd
+++ b/man/scatterHex.Rd
@@ -213,7 +213,7 @@ List elements should be valid inputs to the \code{\link[ggrepel]{geom_label_repe
 
 \item{trajectory.arrow.size}{Number representing the size of trajectory arrows, in inches.  Default = 0.15.}
 
-\item{add.xline}{Numeric value(s) where one or multiple vertical line(s) should be added.}
+\item{add.xline}{Numeric value(s), denoting x-axis value(s), where one or more vertical line(s) should be added.}
 
 \item{xline.linetype}{String which sets the type of line for \code{add.xline}.
 Defaults to "dashed", but any ggplot linetype will work.}
@@ -227,7 +227,7 @@ Alternatively, a vector of numbers of the same length as \code{add.xline} can be
 \item{xline.opacity}{Number that sets the opacity of the \code{add.xline} line(s). Default = 1.
 Alternatively, a vector of numbers of the same length as \code{add.xline} can be given to set the opacity of each line individually.}
 
-\item{add.yline}{Numeric value(s) where one or multiple vertical line(s) should be added.}
+\item{add.yline}{Numeric value(s), denoting y-axis value(s), where one or multiple horizonal line(s) should be added.}
 
 \item{yline.linetype}{String which sets the type of line for \code{add.yline}.
 Defaults to "dashed", but any ggplot linetype will work.}
@@ -241,7 +241,8 @@ Alternatively, a vector of numbers of the same length as \code{add.yline} can be
 \item{yline.opacity}{Number that sets the opacity of the \code{add.yline} line(s). Default = 1.
 Alternatively, a vector of numbers of the same length as \code{add.yline} can be given to set the opacity of each line individually.}
 
-\item{add.abline}{Numeric value(s) where one or multiple diagonal line(s) should be added.}
+\item{add.abline}{Numeric value(s), denoting y-axis intercept(s), where one or multiple diagonal line(s) should be added.
+Use \code{abline.slope} to set slope(s).}
 
 \item{abline.slope}{Number that sets the slope of the \code{add.abline} line(s). Default = 1.
 Alternatively, a vector of numbers of the same length as \code{add.abline} can be given to set the slope of each line individually.}

--- a/man/scatterHex.Rd
+++ b/man/scatterHex.Rd
@@ -196,7 +196,7 @@ When turned on, so number to value mapping can be known, these numbers are added
 
 \item{labels.numbers.spacer}{String. When \code{do.label = TRUE} and \code{labels.use.numbers}, this string is used in the legend between the numbers and their associated data values.}
 
-\item{labels.repel}{Logical, that sets whether the labels' placements will be adjusted with \link{ggrepel} to avoid intersections between labels and plot bounds when \code{do.label = TRUE}.
+\item{labels.repel}{Logical, that sets whether the labels' placements will be adjusted with \link[ggrepel]{ggrepel} to avoid intersections between labels and plot bounds when \code{do.label = TRUE}.
 TRUE by default.}
 
 \item{labels.split.by}{String of one or two column names which controls the facet-split calculations for label placements.

--- a/man/scatterPlot.Rd
+++ b/man/scatterPlot.Rd
@@ -56,9 +56,19 @@ scatterPlot(
   add.xline = NULL,
   xline.linetype = "dashed",
   xline.color = "black",
+  xline.linewidth = 0.5,
+  xline.opacity = 1,
   add.yline = NULL,
   yline.linetype = "dashed",
   yline.color = "black",
+  yline.linewidth = 0.5,
+  yline.opacity = 1,
+  add.abline = NULL,
+  abline.slope = 1,
+  abline.linetype = "solid",
+  abline.color = "black",
+  abline.linewidth = 0.5,
+  abline.opacity = 1,
   do.letter = FALSE,
   do.ellipse = FALSE,
   do.label = FALSE,
@@ -205,19 +215,50 @@ Defaults to "solid", but see \code{\link[ggplot2]{linetype}} for other options.}
 
 \item{trajectory.arrow.size}{Number representing the size of trajectory arrows, in inches.  Default = 0.15.}
 
-\item{add.xline}{numeric value(s) where one or multiple vertical line(s) should be added.}
+\item{add.xline}{Numeric value(s) where one or multiple vertical line(s) should be added.}
 
 \item{xline.linetype}{String which sets the type of line for \code{add.xline}.
 Defaults to "dashed", but any ggplot linetype will work.}
 
-\item{xline.color}{String that sets the color(s) of the \code{add.xline} line(s).}
+\item{xline.color}{String that sets the color(s) of the \code{add.xline} line(s). Default = "black".
+Alternatively, a vector of strings of the same length as \code{add.xline} can be given to set the color of each line individually.}
 
-\item{add.yline}{numeric value(s) where one or multiple vertical line(s) should be added.}
+\item{xline.linewidth}{Number that sets the linewidth of the \code{add.xline} line(s). Default = 0.5.
+Alternatively, a vector of numbers of the same length as \code{add.xline} can be given to set the linewidth of each line individually.}
+
+\item{xline.opacity}{Number that sets the opacity of the \code{add.xline} line(s). Default = 1.
+Alternatively, a vector of numbers of the same length as \code{add.xline} can be given to set the opacity of each line individually.}
+
+\item{add.yline}{Numeric value(s) where one or multiple vertical line(s) should be added.}
 
 \item{yline.linetype}{String which sets the type of line for \code{add.yline}.
 Defaults to "dashed", but any ggplot linetype will work.}
 
-\item{yline.color}{String that sets the color(s) of the \code{add.yline} line(s).}
+\item{yline.color}{String that sets the color(s) of the \code{add.yline} line(s). Default = "black".
+Alternatively, a vector of strings of the same length as \code{add.yline} can be given to set the color of each line individually.}
+
+\item{yline.linewidth}{Number that sets the linewidth of the \code{add.yline} line(s). Default = 0.5.
+Alternatively, a vector of numbers of the same length as \code{add.yline} can be given to set the linewidth of each line individually.}
+
+\item{yline.opacity}{Number that sets the opacity of the \code{add.yline} line(s). Default = 1.
+Alternatively, a vector of numbers of the same length as \code{add.yline} can be given to set the opacity of each line individually.}
+
+\item{add.abline}{Numeric value(s) where one or multiple diagonal line(s) should be added.}
+
+\item{abline.slope}{Number that sets the slope of the \code{add.abline} line(s). Default = 1.
+Alternatively, a vector of numbers of the same length as \code{add.abline} can be given to set the slope of each line individually.}
+
+\item{abline.linetype}{String which sets the type of line for \code{add.abline}.
+Defaults to "dashed", but any ggplot linetype will work.}
+
+\item{abline.color}{String that sets the color(s) of the \code{add.abline} line(s). Default = "black".
+Alternatively, a vector of strings of the same length as \code{add.abline} can be given to set the color of each line individually.}
+
+\item{abline.linewidth}{Number that sets the linewidth of the \code{add.abline} line(s). Default = 0.5.
+Alternatively, a vector of numbers of the same length as \code{add.abline} can be given to set the linewidth of each line individually.}
+
+\item{abline.opacity}{Number that sets the opacity of the \code{add.abline} line(s). Default = 1.
+Alternatively, a vector of numbers of the same length as \code{add.abline} can be given to set the opacity of each line individually.}
 
 \item{do.letter}{Logical which sets whether letters should be added on top of the colored dots.
 For extended colorblindness compatibility.
@@ -410,5 +451,5 @@ out$cols_used
 \code{\link{scatterHex}} for a hex-binned version that can be useful when points are very dense.
 }
 \author{
-Daniel Bunis
+Daniel Bunis, Jared Andrews
 }

--- a/man/scatterPlot.Rd
+++ b/man/scatterPlot.Rd
@@ -215,7 +215,7 @@ Defaults to "solid", but see \code{\link[ggplot2]{linetype}} for other options.}
 
 \item{trajectory.arrow.size}{Number representing the size of trajectory arrows, in inches.  Default = 0.15.}
 
-\item{add.xline}{Numeric value(s) where one or multiple vertical line(s) should be added.}
+\item{add.xline}{Numeric value(s), denoting x-axis value(s), where one or more vertical line(s) should be added.}
 
 \item{xline.linetype}{String which sets the type of line for \code{add.xline}.
 Defaults to "dashed", but any ggplot linetype will work.}
@@ -229,7 +229,7 @@ Alternatively, a vector of numbers of the same length as \code{add.xline} can be
 \item{xline.opacity}{Number that sets the opacity of the \code{add.xline} line(s). Default = 1.
 Alternatively, a vector of numbers of the same length as \code{add.xline} can be given to set the opacity of each line individually.}
 
-\item{add.yline}{Numeric value(s) where one or multiple vertical line(s) should be added.}
+\item{add.yline}{Numeric value(s), denoting y-axis value(s), where one or multiple horizonal line(s) should be added.}
 
 \item{yline.linetype}{String which sets the type of line for \code{add.yline}.
 Defaults to "dashed", but any ggplot linetype will work.}
@@ -243,7 +243,8 @@ Alternatively, a vector of numbers of the same length as \code{add.yline} can be
 \item{yline.opacity}{Number that sets the opacity of the \code{add.yline} line(s). Default = 1.
 Alternatively, a vector of numbers of the same length as \code{add.yline} can be given to set the opacity of each line individually.}
 
-\item{add.abline}{Numeric value(s) where one or multiple diagonal line(s) should be added.}
+\item{add.abline}{Numeric value(s), denoting y-axis intercept(s), where one or multiple diagonal line(s) should be added.
+Use \code{abline.slope} to set slope(s).}
 
 \item{abline.slope}{Number that sets the slope of the \code{add.abline} line(s). Default = 1.
 Alternatively, a vector of numbers of the same length as \code{add.abline} can be given to set the slope of each line individually.}

--- a/man/scatterPlot.Rd
+++ b/man/scatterPlot.Rd
@@ -278,7 +278,7 @@ When turned on, so number to value mapping can be known, these numbers are added
 
 \item{labels.numbers.spacer}{String. When \code{do.label = TRUE} and \code{labels.use.numbers}, this string is used in the legend between the numbers and their associated data values.}
 
-\item{labels.repel}{Logical, that sets whether the labels' placements will be adjusted with \link{ggrepel} to avoid intersections between labels and plot bounds when \code{do.label = TRUE}.
+\item{labels.repel}{Logical, that sets whether the labels' placements will be adjusted with \link[ggrepel]{ggrepel} to avoid intersections between labels and plot bounds when \code{do.label = TRUE}.
 TRUE by default.}
 
 \item{labels.repel.adjust}{A named list which allows extra parameters to be pushed through to ggrepel function calls.

--- a/man/yPlot.Rd
+++ b/man/yPlot.Rd
@@ -69,6 +69,8 @@ yPlot(
   add.line = NULL,
   line.linetype = "dashed",
   line.color = "black",
+  line.linewidth = 0.5,
+  line.opacity = 1,
   legend.show = TRUE,
   legend.title = "make",
   data.out = FALSE
@@ -270,12 +272,19 @@ Overridden by \code{ridgeplot.binwidth} when that input is provided.}
 \item{ridgeplot.binwidth}{Integer which sets the width of chunks to break the x-axis into when \code{ridgeplot.shape = "hist"}.
 Takes precedence over \code{ridgeplot.bins} when provided.}
 
-\item{add.line}{numeric value(s) where one or multiple line(s) should be added}
+\item{add.line}{Numeric value(s) where one or multiple line(s) should be added.}
 
 \item{line.linetype}{String which sets the type of line for \code{add.line}.
 Defaults to "dashed", but any ggplot linetype will work.}
 
-\item{line.color}{String that sets the color(s) of the \code{add.line} line(s)}
+\item{line.color}{String that sets the color(s) of the \code{add.line} line(s). Default = "black".
+Alternatively, a vector of strings of the same length as \code{add.line} can be given to set the color of each line individually.}
+
+\item{line.linewidth}{Number that sets the linewidth of the \code{add.line} line(s). Default = 0.5.
+Alternatively, a vector of numbers of the same length as \code{add.line} can be given to set the linewidth of each line individually.}
+
+\item{line.opacity}{Number that sets the opacity of the \code{add.line} line(s). Default = 1.
+Alternatively, a vector of numbers of the same length as \code{add.line} can be given to set the opacity of each line individually.}
 
 \item{legend.show}{Logical. Whether the legend should be displayed. Default = \code{TRUE}.}
 
@@ -412,5 +421,5 @@ yPlot(data_frame = example_df, group.by = "timepoint",
 \code{\link{ridgePlot}}, \code{\link{ridgeJitter}}, and \code{\link{boxPlot}} for shortcuts to a few 'plots' input shortcuts
 }
 \author{
-Daniel Bunis
+Daniel Bunis, Jared Andrews
 }

--- a/man/yPlot.Rd
+++ b/man/yPlot.Rd
@@ -272,7 +272,7 @@ Overridden by \code{ridgeplot.binwidth} when that input is provided.}
 \item{ridgeplot.binwidth}{Integer which sets the width of chunks to break the x-axis into when \code{ridgeplot.shape = "hist"}.
 Takes precedence over \code{ridgeplot.bins} when provided.}
 
-\item{add.line}{Numeric value(s) where one or multiple line(s) should be added.}
+\item{add.line}{Numeric value(s), denoting y-axis value(s), where one or multiple horizonal line(s) should be added.}
 
 \item{line.linetype}{String which sets the type of line for \code{add.line}.
 Defaults to "dashed", but any ggplot linetype will work.}

--- a/man/yPlot.Rd
+++ b/man/yPlot.Rd
@@ -249,7 +249,7 @@ By default, this input actually controls the value of \code{jitter.position.dodg
 
 \item{vlnplot.scaling}{String which sets how the widths of the of violin plots are set in relation to each other.
 Options are "area", "count", and "width". If the default is not right for your data, I recommend trying "width".
-For an explanation of each, see \code{\link{geom_violin}}.}
+For an explanation of each, see \code{\link[ggplot2]{geom_violin}}.}
 
 \item{vlnplot.quantiles}{Single number or numeric vector of values in [0,1] naming quantiles at which to draw a horizontal line within each violin plot. Example: \code{c(0.1, 0.5, 0.9)}}
 

--- a/tests/testthat/test-bar.R
+++ b/tests/testthat/test-bar.R
@@ -244,3 +244,23 @@ test_that("barPlot, 'retain.factor.level' can be used to respect factor levels",
             rows.use = df[,"grp_factor"]!="C" & df[,"var_factor"]!="Dream"),
         "ggplot")
 })
+
+test_that("barPlot arbitrary horizontal lines work", {
+    # Manual Check:
+    # Multiple lines can be added and their parameters individually adjusted
+    expect_s3_class(
+        barPlot(
+            df, grp2, group.by = grp3, add.line = c(0.25, 0.5), 
+            line.color = c("purple", "cyan"), line.linewidth = 2, 
+            line.opacity = 0.6),
+        "ggplot")
+
+    # Manual Check:
+    # Same lines applied across all panels
+    expect_s3_class(
+        barPlot(
+            df, grp2, group.by = grp3, add.line = c(0.25, 0.5), 
+            line.color = c("purple", "cyan"), line.linewidth = 2, 
+            line.opacity = 0.6, split.by = grp3),
+        "ggplot")
+})

--- a/tests/testthat/test-hex.R
+++ b/tests/testthat/test-hex.R
@@ -394,7 +394,7 @@ test_that("scatterPlot data adjustments applied", {
         max(p$data[[p$cols_used$y.by]]), 1)
 })
 
-test_that("scatterPlot added arbitrary horizontal and vertical lines work", {
+test_that("scatterHex added arbitrary horizontal, vertical, and diagonal lines work", {
     expect_s3_class(
         scatterHex(df, "PC1", "PC2", disc,
                     add.yline = c(-1, 1), add.xline = c(2)),
@@ -406,6 +406,17 @@ test_that("scatterPlot added arbitrary horizontal and vertical lines work", {
         scatterHex(df, "PC1", "PC2", disc,
                     add.yline = c(-1, 1), add.xline = c(2),
                     yline.color = "red", xline.linetype = "dotted"),
+        "ggplot")
+
+    ### Manual Check:
+    # split.by works with lines and ablines work
+    expect_s3_class(
+        scatterHex(df, "PC3", "PC2", disc, split.by = "groups",
+            add.yline = c(-5, 5), add.xline = c(2),
+            yline.color = "red", xline.linetype = "dotted",
+            add.abline = c(5, 1.5), abline.slope = c(2, -3), 
+            abline.linetype = "solid", abline.opacity = c(1, 0.5), abline.linewidth = c(1, 2), 
+            abline.color = c("green", "blue")),
         "ggplot")
 })
 

--- a/tests/testthat/test-scatter.R
+++ b/tests/testthat/test-scatter.R
@@ -676,7 +676,8 @@ test_that("scatterPlot data adjustments applied", {
 test_that("scatterPlot added arbitrary horizontal, vertical, and diagonal lines work", {
     expect_s3_class(
         scatterPlot(df, "PC1", "PC2", disc,
-                    add.yline = c(-1, 1), add.xline = c(2)),
+                    add.yline = c(-1, 1), add.xline = c(2),
+                    add.abline = c(5, 1.5), abline.slope = c(0.02, -0.03)),
         "ggplot")
 
     ### Manual Check:
@@ -689,12 +690,41 @@ test_that("scatterPlot added arbitrary horizontal, vertical, and diagonal lines 
 
     ### Manual Check:
     # split.by works with lines and ablines work
+    # Diagonal lines blue & green,
+    #   with blue thicker than green
+    #   and blue-only see-through
     expect_s3_class(
         scatterPlot(df, "PC3", "PC2", disc, split.by = "groups",
             add.yline = c(-5, 5), add.xline = c(2),
             yline.color = "red", xline.linetype = "dotted",
-            add.abline = c(5, 1.5), abline.slope = c(2, -3), 
-            abline.linetype = "solid", abline.opacity = c(1, 0.5), abline.linewidth = c(1, 2), 
+            add.abline = c(5, 1.5), abline.slope = c(2, -3),
+            abline.linetype = "solid", abline.opacity = c(1, 0.5), abline.linewidth = c(1, 2),
             abline.color = c("green", "blue")),
         "ggplot")
+
+    # Errors and warnings
+    expect_warning(
+        scatterPlot(df, "PC3", "PC2", disc, split.by = "groups",
+                    add.yline = -1, yline.linewidth = 1:2),
+        "'yline.linewidth' must be length 1 or the same length as 'add.yline', using only the first provided value.",
+        fixed = TRUE
+    )
+    expect_warning(
+        scatterPlot(df, "PC3", "PC2", disc, split.by = "groups",
+                    add.xline = -1, xline.linewidth = 1:2),
+        "using only the first provided value",
+        fixed = TRUE
+    )
+    expect_warning(
+        scatterPlot(df, "PC3", "PC2", disc, split.by = "groups",
+                    add.abline = -1, abline.linewidth = 1:2),
+        "using only the first provided value",
+        fixed = TRUE
+    )
+    expect_warning(
+        scatterPlot(df, "PC3", "PC2", disc, split.by = "groups",
+                    add.abline = -1, abline.slope = 1:2),
+        "using only the first provided value",
+        fixed = TRUE
+    )
 })

--- a/tests/testthat/test-scatter.R
+++ b/tests/testthat/test-scatter.R
@@ -673,7 +673,7 @@ test_that("scatterPlot data adjustments applied", {
         max(p$Target_data[[p$cols_used$y.by]]), 1)
 })
 
-test_that("scatterPlot added arbitrary horizontal and vertical lines work", {
+test_that("scatterPlot added arbitrary horizontal, vertical, and diagonal lines work", {
     expect_s3_class(
         scatterPlot(df, "PC1", "PC2", disc,
                     add.yline = c(-1, 1), add.xline = c(2)),
@@ -685,5 +685,16 @@ test_that("scatterPlot added arbitrary horizontal and vertical lines work", {
         scatterPlot(df, "PC1", "PC2", disc,
                     add.yline = c(-1, 1), add.xline = c(2),
                     yline.color = "red", xline.linetype = "dotted"),
+        "ggplot")
+
+    ### Manual Check:
+    # split.by works with lines and ablines work
+    expect_s3_class(
+        scatterPlot(df, "PC3", "PC2", disc, split.by = "groups",
+            add.yline = c(-5, 5), add.xline = c(2),
+            yline.color = "red", xline.linetype = "dotted",
+            add.abline = c(5, 1.5), abline.slope = c(2, -3), 
+            abline.linetype = "solid", abline.opacity = c(1, 0.5), abline.linewidth = c(1, 2), 
+            abline.color = c("green", "blue")),
         "ggplot")
 })

--- a/tests/testthat/test-y.R
+++ b/tests/testthat/test-y.R
@@ -239,7 +239,7 @@ test_that("yPlots x-labels can be adjusted, (y for ridgeplots)", {
         "ggplot")
 })
 
-test_that("yPlot can have lines added", {
+test_that("yPlot can have lines added and adjusted individually", {
     expect_s3_class(
         yPlot(
             df, cont1, group.by = grp,
@@ -255,6 +255,32 @@ test_that("yPlot can have lines added", {
             df, cont1, group.by = grp,
             plots = "ridgeplot",
             add.line = 20, line.linetype = "solid", line.color = "green"),
+        "ggplot")
+    
+    # Manual Check:
+    # Multiple lines, one solid, one dashed, both green, first thick, second thin.
+    expect_s3_class(
+        yPlot(
+            df, cont1, group.by = grp,
+            add.line = c(20, 300), line.linetype = c("solid", "dotdash"), 
+            line.color = "green", line.linewidth = c(0.5, 2)),
+        "ggplot")
+
+    # Manual Check:
+    # Lines applied across panels properly for both ridgeplot and other plots
+    expect_s3_class(
+        yPlot(
+            df, cont1, group.by = grp, split.by = "species",
+            plots = "ridgeplot",
+            add.line = c(20, 300), line.linetype = c("solid", "dotdash"), 
+            line.color = "green", line.linewidth = c(0.5, 2)),
+        "ggplot")
+    
+    expect_s3_class(
+        yPlot(
+            df, cont1, group.by = grp, split.by = "species",
+            add.line = c(20, 300), line.linetype = c("solid", "dotdash"), 
+            line.color = "green", line.linewidth = c(0.5, 2)),
         "ggplot")
 })
 


### PR DESCRIPTION
Re-make of #22 in order to be able to more easily push commits myself

Original Description:

As mentioned in https://github.com/dtm2451/dittoViz/pull/17, this breaks out the line additions to their own functions in utils_plot_mods.R. Biggest changes are the addition of arbitrary ablines, linewidth and opacity parameters, doc additions, and a bit of code refactoring.

It also explicitly mentions that any of the line parameters can accept a vector of the same length of the lines being added to style each individually, e.g.:

```
scatterPlot(
         example_df, x.by = "PC1", y.by = "PC2",
         color.by = "gene1",
         size = 3, add.xline = c(-1, 0, 1), xline.color = c("blue", "red", "green"), 
         xline.linetype = c("dotdash", "dashed", "solid"), xline.opacity = 0.7, xline.linewidth = c(1, 2, 3),
         add.yline = c(-2, 2), yline.color = "magenta", 
         add.abline = c(0, 1), abline.slope = c(1, -0.5), abline.linewidth = 1,
         abline.color = c("skyblue", "darkred"), split.by = "groups")
```

![image](https://github.com/user-attachments/assets/fe06c26e-2fc6-4aec-abe6-b6def53e6799)

Think this is ready for review, tests pass.